### PR TITLE
use pre for errors

### DIFF
--- a/client/src/components/pages/Workspace/Workspace.tsx
+++ b/client/src/components/pages/Workspace/Workspace.tsx
@@ -207,7 +207,7 @@ export const Workspace = () => {
                     <AlertTitle>
                       Ups! Something went wrong with your code
                     </AlertTitle>
-                    <div dangerouslySetInnerHTML={{ __html: compileError }} />
+                    <pre dangerouslySetInnerHTML={{ __html: compileError }} />
                     Fix the code and click <strong>COMPILE</strong> again.
                   </Alert>
                 )}


### PR DESCRIPTION
For preformatted error messages,

Before:

<img width="781" alt="image" src="https://github.com/dpinones/starklings-app/assets/11048263/1acdb76f-ef3e-4841-b403-ead0b81986f0">

After:

<img width="1044" alt="image" src="https://github.com/dpinones/starklings-app/assets/11048263/3c216015-7d48-4b07-9b82-cee11dcd8d93">
