### PR TITLE
Fix exercises

### DIFF
--- a/api/exercises/enums/enums1.cairo
+++ b/api/exercises/enums/enums1.cairo
@@ -1,20 +1,25 @@
+use core::fmt::{Display, Formatter, Error};
+
+#[derive(Drop)]
 enum Message { // TODO: define a few types of messages as used below
 }
 
 fn main() {
-    Message::Quit.print();
-    Message::Echo.print();
-    Message::Move.print();
-    Message::ChangeColor.print();
+    println!("{}", Message::Quit);
+    println!("{}", Message::Echo);
+    println!("{}", Message::Move);
+    println!("{}", Message::ChangeColor);
 }
 
-impl MessagePrintImpl of PrintTrait<Message> {
-    fn print(self: Message) {
-        match self {
-            Message::Quit => println!("Quit"),
-            Message::Echo => println!("Echo"),
-            Message::Move => println!("Move"),
-            Message::ChangeColor => println!("ChangeColor")
-        }
+impl MessageDisplay of Display<Message> {
+    fn fmt(self: @Message, ref f: Formatter) -> Result<(), Error> {
+        let str: ByteArray = match self {
+            Message::Quit => format!("Quit"),
+            Message::Echo => format!("Echo"),
+            Message::Move => format!("Move"),
+            Message::ChangeColor => format!("ChangeColor")
+        };
+        f.buffer.append(@str);
+        Result::Ok(())
     }
 }

--- a/api/exercises/enums/enums2.cairo
+++ b/api/exercises/enums/enums2.cairo
@@ -1,3 +1,5 @@
+use core::fmt::{Display, Formatter, Error};
+
 #[derive(Copy, Drop)]
 enum Message { // TODO: define the different variants used below
 }
@@ -21,19 +23,11 @@ trait MessageTrait<T> {
 
 impl MessageImpl of MessageTrait<Message> {
     fn call(self: Message) {
-        self.print()
+        println!("{}", self);
     }
 }
 
 fn print_messages_recursive(messages: Array<Message>, index: u32) {
-    match gas::withdraw_gas() {
-        Option::Some(_) => {},
-        Option::None => {
-            let mut data = ArrayTrait::<felt252>::new();
-            data.append('OOG');
-            panic(data);
-        },
-    }
     if index >= messages.len() {
         return ();
     }
@@ -43,22 +37,21 @@ fn print_messages_recursive(messages: Array<Message>, index: u32) {
 }
 
 
-impl MessagePrintImpl of PrintTrait<Message> {
-    fn print(self: Message) {
+impl MessageDisplay of Display<Message> {
+    fn fmt(self: @Message, ref f: Formatter) -> Result<(), Error> {
         println!("___MESSAGE BEGINS___");
-        match self {
-            Message::Quit => println!("Quit"),
-            Message::Echo(msg) => println!("{}", msg),
+        let str: ByteArray = match self {
+            Message::Quit => format!("Quit"),
+            Message::Echo(msg) => format!("{}", msg),
             Message::Move((a, b)) => {
-                println!("{}", a);
-                println!("{}",b);
+                format!("{} {}", a, b)
             },
             Message::ChangeColor((red, green, blue)) => {
-                println!("{}",red);
-                println!("{}",green);
-                println!("{}",blue);
+                format!("{} {} {}", red, green, blue)
             }
-        }
+        };
+        f.buffer.append(@str);
         println!("___MESSAGE ENDS___");
+        Result::Ok(())
     }
 }

--- a/api/exercises/loops/loops2.cairo
+++ b/api/exercises/loops/loops2.cairo
@@ -5,7 +5,7 @@ fn test_loop() {
 
     let result = loop {
         if counter == 5 {
-    //TODO return a value from the loop
+            //TODO return a value from the loop
         }
         counter += 1;
     };

--- a/api/exercises/modules/modules1.cairo
+++ b/api/exercises/modules/modules1.cairo
@@ -1,5 +1,5 @@
 mod restaurant {
-    fn take_order() -> felt252 {
+    pub fn take_order() -> felt252 {
         'order_taken'
     }
 }

--- a/api/exercises/modules/modules2.cairo
+++ b/api/exercises/modules/modules2.cairo
@@ -2,29 +2,29 @@ const YEAR: u16 = 2050;
 
 mod order {
     #[derive(Copy, Drop)]
-    struct Order {
+    pub struct Order {
         name: felt252,
         year: u16,
-        made_by_phone: bool,
+        pub made_by_phone: bool,
         made_by_email: bool,
         item: felt252,
     }
 
-    fn new_order(name: felt252, made_by_phone: bool, item: felt252) -> Order {
+    pub fn new_order(name: felt252, made_by_phone: bool, item: felt252) -> Order {
         Order { name, year: YEAR, made_by_phone, made_by_email: !made_by_phone, item,  }
     }
 }
 
 mod order_utils {
-    fn dummy_phoned_order(name: felt252) -> Order {
+    pub fn dummy_phoned_order(name: felt252) -> Order {
         new_order(name, true, 'item_a')
     }
 
-    fn dummy_emailed_order(name: felt252) -> Order {
+    pub fn dummy_emailed_order(name: felt252) -> Order {
         new_order(name, false, 'item_a')
     }
 
-    fn order_fees(order: Order) -> felt252 {
+    pub fn order_fees(order: Order) -> felt252 {
         if order.made_by_phone {
             return 500;
         }

--- a/api/exercises/move_semantics/move_semantics1.cairo
+++ b/api/exercises/move_semantics/move_semantics1.cairo
@@ -4,12 +4,12 @@ fn main() {
     let arr1 = fill_arr(arr0);
 
     // This is just a print statement for arrays.
-    arr1.clone().print();
+    print(arr1.span());
 
     //TODO fix the error here without modifying this line.
     arr1.append(88);
 
-    arr1.print();
+    print(arr1.span());
 }
 
 fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
@@ -20,4 +20,22 @@ fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
     arr.append(66);
 
     arr
+}
+
+fn print(span: Span<felt252>) { 
+    let mut i = 0;
+    print!("PATH: {{ len: {}, values: [ ", span.len());
+    loop {
+        if span.len() == i {
+            break;
+        }
+        let value = *(span.at(i));
+        if span.len() - 1 != i {
+            print!("{}, ", value);
+        } else {
+            print!("{}", value);
+        }
+        i += 1;
+    };
+    println!(" ] }}");
 }

--- a/api/exercises/move_semantics/move_semantics2.cairo
+++ b/api/exercises/move_semantics/move_semantics2.cairo
@@ -4,7 +4,7 @@ fn main() {
     let mut _arr1 = fill_arr(arr0);
 
     // Do not change the following line!
-    arr0.print();
+    print(arr0.span());
 }
 
 fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
@@ -15,4 +15,22 @@ fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
     arr.append(66);
 
     arr
+}
+
+fn print(span: Span<felt252>) { 
+    let mut i = 0;
+    print!("PATH: {{ len: {}, values: [ ", span.len());
+    loop {
+        if span.len() == i {
+            break;
+        }
+        let value = *(span.at(i));
+        if span.len() - 1 != i {
+            print!("{}, ", value);
+        } else {
+            print!("{}", value);
+        }
+        i += 1;
+    };
+    println!(" ] }}");
 }

--- a/api/exercises/move_semantics/move_semantics3.cairo
+++ b/api/exercises/move_semantics/move_semantics3.cairo
@@ -3,11 +3,11 @@ fn main() {
 
     let mut arr1 = fill_arr(arr0);
 
-    arr1.clone().print();
+    print(arr1.span());
 
     arr1.append(88);
 
-    arr1.clone().print();
+    print(arr1.span());
 }
 
 fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
@@ -16,4 +16,22 @@ fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
     arr.append(66);
 
     arr
+}
+
+n print(span: Span<felt252>) { 
+    let mut i = 0;
+    print!("PATH: {{ len: {}, values: [ ", span.len());
+    loop {
+        if span.len() == i {
+            break;
+        }
+        let value = *(span.at(i));
+        if span.len() - 1 != i {
+            print!("{}, ", value);
+        } else {
+            print!("{}", value);
+        }
+        i += 1;
+    };
+    println!(" ] }}");
 }

--- a/api/exercises/move_semantics/move_semantics4.cairo
+++ b/api/exercises/move_semantics/move_semantics4.cairo
@@ -3,11 +3,11 @@ fn main() {
 
     let mut arr1 = fill_arr(arr0);
 
-    arr1.clone().print();
+    print(arr1.span());
 
     arr1.append(88);
 
-    arr1.clone().print();
+    print(arr1.span());
 }
 
 // `fill_arr()` should no longer take `arr: Array<felt252>` as argument
@@ -19,4 +19,22 @@ fn fill_arr(arr: Array<felt252>) -> Array<felt252> {
     arr.append(66);
 
     arr
+}
+
+fn print(span: Span<felt252>) { 
+    let mut i = 0;
+    print!("PATH: {{ len: {}, values: [ ", span.len());
+    loop {
+        if span.len() == i {
+            break;
+        }
+        let value = *(span.at(i));
+        if span.len() - 1 != i {
+            print!("{}, ", value);
+        } else {
+            print!("{}", value);
+        }
+        i += 1;
+    };
+    println!(" ] }}");
 }

--- a/api/exercises/move_semantics/move_semantics6.cairo
+++ b/api/exercises/move_semantics/move_semantics6.cairo
@@ -20,5 +20,5 @@ fn get_value(number: Number) -> u32 {
 fn set_value(number: Number) {
     let value = 2222222;
     number = Number { value };
-    number.value.print();
+    println!("{}", number.value);
 }

--- a/api/exercises/options/options3.cairo
+++ b/api/exercises/options/options3.cairo
@@ -6,23 +6,11 @@ struct Student {
 
 
 fn display_grades(student: @Student, index: usize) {
-    // don't mind these lines! They are required when
-    // running recursive functions.
-    match gas::withdraw_gas() {
-        Option::Some(_) => {},
-        Option::None => {
-            let mut data = ArrayTrait::new();
-            data.append('Out of gas');
-            panic(data);
-        },
-    }
 
     if index == 0 {
-        let mut msg = ArrayTrait::new();
-        msg.append(*student.name);
-        msg.append('\'s grades:');
-        debug::print(msg);
+        println!("{} index 0", *student.name);
     }
+    
     if index >= student.courses.len() {
         return ();
     }

--- a/api/exercises/starknet/basics/starknet1.cairo
+++ b/api/exercises/starknet/basics/starknet1.cairo
@@ -17,12 +17,11 @@ mod JoesContract {
 
 #[cfg(test)]
 mod test {
+    use starknet::syscalls::deploy_syscall;
+    use starknet::ContractAddress;
     use super::JoesContract;
     use super::IJoesContractDispatcher;
     use super::IJoesContractDispatcherTrait;
-    use starknet::syscalls::deploy_syscall;
-    use starknet::class_hash::Felt252TryIntoClassHash;
-    use starknet::ContractAddress;
 
     #[test]
     #[available_gas(2000000000)]

--- a/api/exercises/starknet/basics/starknet2.cairo
+++ b/api/exercises/starknet/basics/starknet2.cairo
@@ -29,13 +29,11 @@ trait IJillsContract<TContractState> {
 
 #[cfg(test)]
 mod test {
+    use starknet::ContractAddress;
+    use starknet::syscalls::deploy_syscall;
     use super::JillsContract;
     use super::IJillsContractDispatcher;
     use super::IJillsContractDispatcherTrait;
-    use starknet::ContractAddress;
-    use starknet::syscalls::deploy_syscall;
-    use starknet::class_hash::Felt252TryIntoClassHash;
-    use starknet::Felt252TryIntoContractAddress;
     
     #[test]
     #[available_gas(2000000000)]

--- a/api/exercises/starknet/basics/starknet3.cairo
+++ b/api/exercises/starknet/basics/starknet3.cairo
@@ -44,13 +44,11 @@ mod ProgressTracker {
 
 #[cfg(test)]
 mod test {
+    use starknet::ContractAddress;
+    use starknet::syscalls::deploy_syscall;
     use super::ProgressTracker;
     use super::IProgressTrackerDispatcher;
     use super::IProgressTrackerDispatcherTrait;
-    use starknet::ContractAddress;
-    use starknet::syscalls::deploy_syscall;
-    use starknet::Felt252TryIntoContractAddress;
-
 
     #[test]
     #[available_gas(2000000000)]

--- a/api/exercises/starknet/basics/starknet4.cairo
+++ b/api/exercises/starknet/basics/starknet4.cairo
@@ -57,14 +57,9 @@ mod LizInventory {
 mod test {
     use starknet::ContractAddress;
     
-    use array::SpanTrait;
-    
-    use traits::TryInto;
     use starknet::syscalls::deploy_syscall;
     use core::result::ResultTrait;
 
-    use starknet::Felt252TryIntoContractAddress;
-    
     use super::LizInventory;
     use super::ILizInventoryDispatcher;
     use super::ILizInventoryDispatcherTrait;

--- a/api/exercises/starknet/interoperability/starknet5.cairo
+++ b/api/exercises/starknet/interoperability/starknet5.cairo
@@ -7,7 +7,6 @@ trait IContractA<TContractState> {
 
 #[starknet::contract]
 mod ContractA {
-    use starknet::info::get_contract_address;
     use starknet::ContractAddress;
     use super::IContractBDispatcher;
     use super::IContractBDispatcherTrait;
@@ -72,7 +71,6 @@ mod ContractB {
 #[cfg(test)]
 mod test {
     use starknet::syscalls::deploy_syscall;
-    use starknet::class_hash::Felt252TryIntoClassHash;
     use starknet::ContractAddress;
     use super::ContractA;
     use super::IContractADispatcher;


### PR DESCRIPTION
I corrected exercises that were failing due to being written in the syntax of an older version of Cairo

- [x] enums1
- [x] enums2
- [x] loops2
- [x] modules1
- [x] modules2
- [x] move_semantics1
- [x] move_semantics2
- [x] move_semantics3
- [x] move_semantics4
- [x] move_semantics6
- [x] options3
- [x] starknet1
- [x] starknet2
- [x] starknet3
- [x] starknet4
- [x] starknet5







