### PR TITLE
166 Use codicon font for code block arrows

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -27,3 +27,7 @@ h1, h2, h3, h4, h5, h6 {
 a, button {
   border-radius: 0 !important;
 }
+
+.codicon {
+  font-family: codicon, monospace !important;
+}


### PR DESCRIPTION
Use `codicon` default font from Monaco editor