### PR TITLE
fix: variables5.cairo wrong comment

### DIFF
--- a/api/exercises/variables/variables5.cairo
+++ b/api/exercises/variables/variables5.cairo
@@ -1,6 +1,6 @@
 fn main() {
     let number = 1_u8; // don't change this line
     println!("number is {}", number);
-    number = 3; // don't change this line
+    number = 3; // don't rename this variable
     println!("number is {}", number);
 }


### PR DESCRIPTION
change wrong comment```// don't change this line``` to ```// don't rename this variable``` be like in https://github.com/shramee/starklings-cairo1/blob/main/exercises/variables/variables5.cairo