### PR TITLE
Minor frontend fixes

### DIFF
--- a/client/src/components/pages/Home/Home.tsx
+++ b/client/src/components/pages/Home/Home.tsx
@@ -31,7 +31,7 @@ export const Home = () => {
       }}
     >
       <Logo />
-      <Typography sx={{ mt: 3, px:2 }}>
+      <Typography sx={{ mt: 3, px:2, textAlign: "center" }}>
         A web-based interactive tutorial to learn Cairo and Starknet.
       </Typography>
 

--- a/client/src/components/shared/Logo.tsx
+++ b/client/src/components/shared/Logo.tsx
@@ -6,7 +6,7 @@ interface ILogoProps {
   fontSize?: string;
 }
 
-export const Logo = ({ text = "starklings.app", fontSize = "14.2vw" }: ILogoProps) => {
+export const Logo = ({ text = "starklings.app", fontSize = "10.2vw" }: ILogoProps) => {
   return (
     <Box
       sx={{


### PR DESCRIPTION
Decreased the size of the logo and centered the text below to stop this from happening in smaller displays:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/5c517117-5c0a-4d3a-85f8-f776a17f57a0" />