### PR TITLE
Change from LegacyMap to Map in starknet3

### DIFF
--- a/api/exercises/starknet/basics/starknet3.cairo
+++ b/api/exercises/starknet/basics/starknet3.cairo
@@ -11,12 +11,13 @@ trait IProgressTracker<TContractState> {
 mod ProgressTracker {
     use starknet::ContractAddress;
     use starknet::get_caller_address; // Required to use get_caller_address function
-
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry, Map};
+    
     #[storage]
     struct Storage {
         contract_owner: ContractAddress,
-        // TODO: Set types for LegacyMap
-        progress: LegacyMap<>
+        // TODO: Set types for Map
+        progress: Map<>
     }
 
     #[constructor]


### PR DESCRIPTION
Since LegacyMap is deprecated I changed to Map in the starknet3 exercise. This also reflects the change in the starklings-cairo1 repo: https://github.com/shramee/starklings-cairo1/issues/224